### PR TITLE
switching over to maven dependencies

### DIFF
--- a/src/test/java/ColumnTester.java
+++ b/src/test/java/ColumnTester.java
@@ -1,4 +1,4 @@
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ColumnTester   {
     @Test


### PR DESCRIPTION
previously my tester class was using a separate JUnit jar I had downloaded, it has been converted over to use the version of JUnit present in our Maven dependencies 